### PR TITLE
[DOCS] Drop :ts: text role alias

### DIFF
--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -13,8 +13,6 @@
 .. role:: rst(code)
 .. role:: sep(strong)
 .. role:: sql(code)
-.. role:: ts(code)
-   :class: typoscript
 
 .. role:: tsconfig(code)
    :class: typoscript


### PR DESCRIPTION
The ambiguous :ts: text role has been removed to
not confuse the writer with typescript and typoscript.

Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/181