### PR TITLE
[DOCS] Reference manual's start page with :doc:`<manual>:Index`

### DIFF
--- a/Documentation/OverviewOfManuals/00ListOfManualsAbout.rst
+++ b/Documentation/OverviewOfManuals/00ListOfManualsAbout.rst
@@ -42,7 +42,7 @@ Scope of DocTeam Pages
    :Scope:        About
    :Comment:      Comment
 
- - :Manual:       :ref:`h2document:start` (Guide)
+ - :Manual:       :doc:`h2document:Index` (Guide)
    :Scope:        Main documentation for writing documentation on docs.typo3.org,
                   for contributors, extension developers (and Documentation Team).
    :Comment:      Use this as main resource for contributors!
@@ -67,17 +67,17 @@ Scope of DocTeam Pages
 
  - :Manual:       "About TYPO3 Documentation" on "glue pages" https://docs.typo3.org/About.html
    :Scope:        Contains documentation news, Tips & Tricks ...
-   :Comment:      :ref:`h2document:start` now being used as main resource for contributors.
+   :Comment:      :doc:`h2document:Index` now being used as main resource for contributors.
                   In order to not have information in too many different places, the pages
                   "Contribution" and "Writing Documentation" have been replaced by external
-                  links to :ref:`h2document:start`.
+                  links to :doc:`h2document:Index`.
 
  - :Manual:       "Tips" on "start page" https://docs.typo3.org/
    :Scope:        **Changed:** Mostly tips about **using** (reading) documentation and
                   **general tips about TYPO3 or where to find things**!
    :Comment:      "Writing Documentation" now being used as main resource for contributors.
                   Because of this, the **tips on writing** documentation have been moved to
-                  :ref:`h2document:start` (see startpage).
+                  :doc:`h2document:Index` (see startpage).
 
 
  - :Manual:       Forge Wiki: https://forge.typo3.org/projects/team-docteam

--- a/Documentation/OverviewOfManuals/00ListOfManualsMaintainer.rst
+++ b/Documentation/OverviewOfManuals/00ListOfManualsMaintainer.rst
@@ -17,52 +17,52 @@ Main Manuals
  - :Manual:       Manual
    :Maintainer:   Maintainer
 
- - :Manual:       :ref:`t3l10n:start`
+ - :Manual:       :doc:`t3l10n:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3install:start`
+ - :Manual:       :doc:`t3install:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3security:start` (Merged into TYPO3 Explained)
+ - :Manual:       :doc:`t3security:Index` (Merged into TYPO3 Explained)
    :Maintainer:   Michael Schams
 
  - :Manual:       `Site Package Tutorial <https://docs.typo3.org/typo3cms/SitePackageTutorial/>`__
    :Maintainer:   Michael Schams
 
- - :Manual:       :ref:`t3contribute:start`
+ - :Manual:       :doc:`t3contribute:Index`
    :Maintainer:   Sybille Peters, Josef Glatz
 
- - :Manual:       :ref:`t3extbasebook:start`
+ - :Manual:       :doc:`t3extbasebook:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3extbase:start`
+ - :Manual:       :doc:`t3extbase:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3start:start`
+ - :Manual:       :doc:`t3start:Index`
    :Maintainer:   Sybille Peters
 
- - :Manual:       :ref:`t3editors:start`
+ - :Manual:       :doc:`t3editors:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3ts45:start`
+ - :Manual:       :doc:`t3ts45:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3templating:start`
+ - :Manual:       :doc:`t3templating:Index`
    :Maintainer:
 
  - :Manual:       `Core ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/latest/>`__
    :Maintainer:   Christian Kuhn
 
- - :Manual:       :ref:`Core API <t3coreapi:start>`
+ - :Manual:       :doc:`Core API <t3coreapi:Index>`
    :Maintainer:   Christian Kuhn
 
- - :Manual:       :ref:`t3tca:start`
+ - :Manual:       :doc:`t3tca:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3tsconfig:start`
+ - :Manual:       :doc:`t3tsconfig:Index`
    :Maintainer:
 
- - :Manual:       :ref:`t3tsref:start`
+ - :Manual:       :doc:`t3tsref:Index`
    :Maintainer:
 
 Other
@@ -98,7 +98,7 @@ Writing Documentation and DocTeam (Maintainer)
  - :Manual:       :ref:`start` (this manual)
    :Maintainer:   Documentation Team
 
- - :Manual:       :ref:`h2document:start`
+ - :Manual:       :doc:`h2document:Index`
    :Maintainer:   Martin Bless, Sybille Peters
 
  - :Manual:       Team page on **typo3.org**: https://typo3.org/community/teams/documentation/

--- a/Documentation/OverviewOfManuals/00ListOfManualsReview.rst
+++ b/Documentation/OverviewOfManuals/00ListOfManualsReview.rst
@@ -33,27 +33,27 @@ Review Status of Main Manuals
    :InProgress:   In progress
    :NextStep:     Next Step
 
- - :Manual:       :ref:`t3l10n:start`
+ - :Manual:       :doc:`t3l10n:Index`
    :State:        **outdated** Versions 7.6 until master (10) have not been thoroughly reviewed yet.
    :InProgress:
    :NextStep:     Decision: Should probably be merged to "TYPO3 Explained"?
 
- - :Manual:       :ref:`t3install:start`
+ - :Manual:       :doc:`t3install:Index`
    :State:        **good** Generally, "master" (10) and 9.5 version looks good and up-to-date.
    :InProgress:
    :NextStep:
 
- - :Manual:       :ref:`t3sitepackage:start`
+ - :Manual:       :doc:`t3sitepackage:Index`
    :State:        "master" is for TYPO3 8.7
    :InProgress:
    :NextStep:     Check if changes for 9 and 10 are necessary, branch out and create changes for 9 and 10.
 
- - :Manual:       :ref:`t3contribute:start`
+ - :Manual:       :doc:`t3contribute:Index`
    :State:        **good** Up-to-date, proofread (4/2018)
    :InProgress:
    :NextStep:
 
- - :Manual:       :ref:`t3extbasebook:start`
+ - :Manual:       :doc:`t3extbasebook:Index`
    :State:        **needs revision** Was often mentioned, that it is not up-to-date. Was also mentioned,
                   that language needs improvement. Text partially long winded. Could be shortened. Outdated
                   example extensions.
@@ -63,27 +63,27 @@ Review Status of Main Manuals
                   remove other branches from being rendered or add outdated notice. Review for: up-to-date,
                   proofread language, shorten text, make it better readable.
 
- - :Manual:       :ref:`t3extbase:start`
+ - :Manual:       :doc:`t3extbase:Index`
    :State:        **to be deprecated** outdated and incomplete
    :InProgress:
    :NextStep:     Move existing information and add redirects
 
- - :Manual:       :ref:`t3start:start`
+ - :Manual:       :doc:`t3start:Index`
    :State:        9.5 branch fully updated, master (10) to be updated, other branches: unclear
    :InProgress:
    :NextStep:     No immediate action required.
 
- - :Manual:       :ref:`t3editors:start`
+ - :Manual:       :doc:`t3editors:Index`
    :State:        Current master for TYPO3 8
    :InProgress:
    :NextStep:     Branch out and update "master" for 9 (and 10)
 
- - :Manual:       :ref:`t3ts45:start`
+ - :Manual:       :doc:`t3ts45:Index`
    :State:
    :InProgress:
    :NextStep:      Assess quality. Check what is outdated. Is it still helpful in its current form?
 
- - :Manual:       :ref:`t3templating:start`
+ - :Manual:       :doc:`t3templating:Index`
    :State:        todo
    :InProgress:
    :NextStep:     todo
@@ -93,22 +93,22 @@ Review Status of Main Manuals
    :InProgress:
    :NextStep:
 
- - :Manual:       :ref:`Core API <t3coreapi:start>`
+ - :Manual:       :doc:`Core API <t3coreapi:Index>`
    :State:        Mostly in good shape. Some parts outdated. Some parts missing.
    :InProgress:
    :NextStep:     Check entire manual, if up-to-date for TYPO3 9 (latest). Add missing information.
 
- - :Manual:       :ref:`t3tca:start`
+ - :Manual:       :doc:`t3tca:Index`
    :State:        unclear
    :InProgress:
    :NextStep:
 
- - :Manual:       :ref:`t3tsconfig:start`
+ - :Manual:       :doc:`t3tsconfig:Index`
    :State:        unclear
    :InProgress:
    :NextStep:
 
- - :Manual:       :ref:`t3tsref:start`
+ - :Manual:       :doc:`t3tsref:Index`
    :State:        unclear
    :InProgress:
    :NextStep:
@@ -218,7 +218,7 @@ correcting) the information.
    :InProgress:
    :NextStep:
 
- - :Manual:       :ref:`h2document:start`
+ - :Manual:       :doc:`h2document:Index`
    :State:        **good** Fully revised, up-to-date! (May 2019)
    :InProgress:
    :NextStep:


### PR DESCRIPTION
Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185